### PR TITLE
Force creation of Avatar Image

### DIFF
--- a/forms/FormAvatar.php
+++ b/forms/FormAvatar.php
@@ -126,6 +126,11 @@ class FormAvatar extends \AvatarWidgetBase
                         'center_center'
                     ));
 
+                    // Force creation of Image to overcome Contao's Deferred image loading function
+                    if (method_exists(\File::class, 'createIfDeferred')) {
+                        (new File($this->varValue))->createIfDeferred();
+                    }
+                    
                     // Copy the file
                     if (\Files::getInstance()->rename($this->varValue, $strNew)) {
                         $this->varValue   = $strNew;


### PR DESCRIPTION
Due to Contao deferred image loading. End images inside `/assets` folder are created only when viewed in frontend. But for Avatar to move the profile image inside `assets/avatars/members` folder you need the image file physically. Otherwise`\Files::getInstance()->rename` or rather php `raname()` will not work and thus you can not create Avatar profile image.